### PR TITLE
Fix the `very_terse` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ also_fine: [
     3,
 ]
 
-very_terse: [1, 2, 3]
+very_terse: [1 2 3]
 ```
 
 A list can contain any Eon value (including other lists).


### PR DESCRIPTION
Currently, it's the same as `short_list`, but I'm guessing it was meant to be this intead.